### PR TITLE
Updates to handle old and broken tapes.

### DIFF
--- a/itstar.c
+++ b/itstar.c
@@ -399,6 +399,14 @@ static void extfiles(int argc,char **argv)
 	scantape(argc,argv,extfile);
 }
 
+/* skip a single file */
+static void skipfile()
+{
+	while (taperead() >= 0)
+		;
+	taperead();
+}
+
 /* extract a single file (called back by scantape()) */
 static void extfile()
 {
@@ -542,9 +550,10 @@ static void scantape(int argc,char **argv,void (*process)())
 	while(taperead()==0) {	/* read file label */
 	fhead:	inword(&l,&r);	/* 1: AOBJN ptr giving length */
 		len=01000000L-l; /* length of record */
-		if(len<4) {	/* must have at least filename */
-			fprintf(stderr,"?Invalid tape format\n");
-			exit(1);
+		if(len<4||len>10) {
+			fprintf(stderr,"?Invalid tape file header\n");
+			skipfile();
+			goto fhead;
 		}
 		insix(ufd);	/* 2: UFD */
 		insix(fn1);	/* 3: FN1 */

--- a/itstar.c
+++ b/itstar.c
@@ -400,7 +400,7 @@ static void extfiles(int argc,char **argv)
 }
 
 /* skip a single file */
-static void skipfile()
+void skipfile()
 {
 	while (taperead() >= 0)
 		;
@@ -446,7 +446,6 @@ static void extfile()
 		sprintf(lname,"%s/%s.%s",lufd,lfn1,lfn2);  /* combine */
 		if(symlink(lname,fname)<0) {  /* create link */
 			perror(fname);
-			exit(1);
 		}
 		/* can't apply dates since target may not exist */
 		taperead();		/* read the EOF mark */
@@ -462,7 +461,7 @@ static void extfile()
 			else u.actime=u.modtime;  /* use creation date if not */
 			if(utime(fname,&u)<0) {
 				perror("?Error setting file dates");
-				exit(1);
+				taperead(); /* read the EOF mark */
 			}
 		}
 	}

--- a/itstar.h
+++ b/itstar.h
@@ -4,6 +4,7 @@ void save(char *f);
 void resetbuf();
 void tapeflush();
 int taperead();
+void skipfile();
 void inword(long *l,long *r);
 void outword(register unsigned long l,register unsigned long r);
 int nextword(long *l,long *r);

--- a/pack.c
+++ b/pack.c
@@ -204,7 +204,8 @@ void pack(char *file)
 	out=fopen(file,"wb");	/* create output file */
 	if(out==NULL) {
 		perror(file);
-		exit(1);
+		skipfile();
+		return;
 	}
 
 	if((remaining()==0)&&(taperead()<0)) {


### PR DESCRIPTION
if you see "?Tape record too short" it probably means a tape file header was invalid.  There may still be valid files after the damaged one, so this makes itstar skip the bad file and try the next.

CC @eswenson1 