### PR TITLE
Read and write 7-track tapes.

### DIFF
--- a/itstar.c
+++ b/itstar.c
@@ -52,6 +52,7 @@ extern unsigned long bpi;	/* tape density in bits per inch */
 extern unsigned long count;	/* count of tape frames written */
 extern int simh;		/* NZ to support SIMH tape images */
 int seven_track = 0;		/* NZ to write 7-track tape images */
+int big_endian = 0;		/* NZ to read big endian record length */
 
 static void usage(), itsname(), extitsname(), changedir();
 static void addfiles(), addfile(), listfiles(), listfile(),
@@ -132,6 +133,9 @@ int main(int argc,char **argv)
 					break;
 				case '7':	/* 7-track tape images */
 					seven_track=1;
+					break;
+				case 'B':	/* Big endian record lenght */
+					big_endian=1;
 					break;
 				default:
 					fprintf(stderr,"?Invalid option: %c\n",

--- a/itstar.c
+++ b/itstar.c
@@ -51,6 +51,7 @@
 extern unsigned long bpi;	/* tape density in bits per inch */
 extern unsigned long count;	/* count of tape frames written */
 extern int simh;		/* NZ to support SIMH tape images */
+int seven_track = 0;		/* NZ to write 7-track tape images */
 
 static void usage(), itsname(), extitsname(), changedir();
 static void addfiles(), addfile(), listfiles(), listfile(),
@@ -128,6 +129,9 @@ int main(int argc,char **argv)
 					break;
 				case 'x':	/* extract files */
 					extract=1;
+					break;
+				case '7':	/* 7-track tape images */
+					seven_track=1;
 					break;
 				default:
 					fprintf(stderr,"?Invalid option: %c\n",

--- a/tm03.c
+++ b/tm03.c
@@ -2,13 +2,16 @@
 
   Versions of inword() and outword() to convert between 36-bit PDP-10 words and
   the 8-bit "core dump" format used by the TM03 formatter found in the TU45,
-  TU77 etc.
+  TU77 etc.  Also writes 7-track tape images.
 
   The TM03 packs each 36-bit word into 5 consecutive tape frames.  The leftmost
   32 bits of the word are stored in the first 4 tape frames (ordered from left
   to right), and the remaining four bits are stored in the low half of the 5th
   tape frame.  The left half of the 5th bit is written as 0000 and treated as
   "don't care" data on read.
+
+  A 7-track tape image stores a 36-bit word as six tape frames with
+  six bits in each frame.  There is also a parity bit.
 
   Entry points:
   resetbuf, tapeflush, taperead, inword, outword, remaining.
@@ -41,11 +44,15 @@
 
 //#define RECLEN (5*512)	/* we deal in 512-word records */
 //			/* (AI:SYSDOC;DUMP FORMAT says 1024 but it's wrong) */
-#define RECLEN (10*512)	/* maybe it's not so wrong after all */
+#define RECLEN9 (5*1024)	/* maybe it's not so wrong after all */
+#define RECLEN7 (6*1024)
+#define RECLEN (seven_track ? RECLEN7 : RECLEN9)
+
+extern int seven_track;
 
 void outword();
 
-static char tapebuf[RECLEN];  /* tape I/O buffer */
+static char tapebuf[RECLEN7];  /* tape I/O buffer */
 static char *tapeptr;	/* ptr to next posn in tapebuf[] */
 static int recl;	/* record length on read */
 
@@ -74,9 +81,16 @@ int taperead()
 {
 	recl=getrec(tapebuf,RECLEN);
 	if(recl<=0) return(-1);	/* EOF */
-	if(recl%5) {		/* TM03 stores words as 5 tape frames */
-		fprintf(stderr,"?Record length not word multiple\n");
-		exit(1);
+	if (seven_track) {
+		if(recl%6) {		/* 7-track tapes store words as 6 tape frames */
+			fprintf(stderr,"?Record length not word multiple\n");
+			exit(1);
+		}
+	} else {
+		if(recl%5) {		/* TM03 stores words as 5 tape frames */
+			fprintf(stderr,"?Record length not word multiple\n");
+			exit(1);
+		}
 	}
 	tapeptr=tapebuf;
 	return(0);
@@ -90,6 +104,23 @@ void inword(long *l,long *r)
 	if(recl==0) {			/* no more data */
 		fprintf(stderr,"?Tape record too short\n");
 		exit(1);
+	}
+
+	if (seven_track) {
+		/* left half */
+		a=*tapeptr++;
+		b=*tapeptr++;
+		c=*tapeptr++;
+		*l=((a<<12)&0770000)|((b<<6)&0007700)|(c&077);
+
+		/* right half */
+		a=*tapeptr++;
+		b=*tapeptr++;
+		c=*tapeptr++;
+		*r=((a<<12)&0770000)|((b<<6)&0007700)|(c&077);
+
+		recl -= 6;
+		return;
 	}
 
 	/* left half */
@@ -115,6 +146,23 @@ int nextword(long *l,long *r)
 	if(recl==0)			/* no more data */
 		if(taperead()<0) return(-1);
 
+	if (seven_track) {
+		/* left half */
+		a=*tapeptr++;
+		b=*tapeptr++;
+		c=*tapeptr++;
+		*l=((a<<12)&0770000)|((b<<6)&0007700)|(c&077);
+
+		/* right half */
+		a=*tapeptr++;
+		b=*tapeptr++;
+		c=*tapeptr++;
+		*r=((a<<12)&0770000)|((b<<6)&0007700)|(c&077);
+
+		recl -= 6;
+		return 0;
+	}
+
 	/* left half */
 	a=*tapeptr++;
 	b=*tapeptr++;
@@ -133,17 +181,38 @@ int nextword(long *l,long *r)
 /* return # of words remaining in buffer */
 int remaining()
 {
-	return(recl/5);
+	if (seven_track)
+		return(recl/6);
+	else
+		return(recl/5);
 }
 
 /* write a word */
 void outword(register unsigned long l,register unsigned long r)
 {
-	*tapeptr++=(l>>10)&0377;
-	*tapeptr++=(l>>2)&0377;
-	*tapeptr++=((l<<6)&0300)|((r>>12)&077);
-	*tapeptr++=(r>>4)&0377;
-	*tapeptr++=r&017;
+	if (seven_track) {
+		int i, c, p;
+		for (i = 0; i < 3; i++) {
+			c = (l >> 12) & 077;
+			p = 0100 ^ (c << 1) ^ (c << 2) ^ (c << 3) ^ (c << 4) ^ (c << 5) ^ (c << 6);
+			c |= p & 0100;
+			*tapeptr++ = c;
+			l <<= 6;
+		}
+		for (i = 0; i < 3; i++) {
+			c = (r >> 12) & 077;
+			p = 0100 ^ (c << 1) ^ (c << 2) ^ (c << 3) ^ (c << 4) ^ (c << 5) ^ (c << 6);
+			c |= p & 0100;
+			*tapeptr++ = c;
+			r <<= 6;
+		}
+	} else {
+		*tapeptr++=(l>>10)&0377;
+		*tapeptr++=(l>>2)&0377;
+		*tapeptr++=((l<<6)&0300)|((r>>12)&077);
+		*tapeptr++=(r>>4)&0377;
+		*tapeptr++=r&017;
+	}
 
 	/* see if the buffer needs to be flushed */
 	if(tapeptr==tapebuf+RECLEN) tapeflush();

--- a/tm03.c
+++ b/tm03.c
@@ -42,9 +42,8 @@
 
 #include "itstar.h"
 
-//#define RECLEN (5*512)	/* we deal in 512-word records */
-//			/* (AI:SYSDOC;DUMP FORMAT says 1024 but it's wrong) */
-#define RECLEN9 (5*1024)	/* maybe it's not so wrong after all */
+/* AI:SYSDOC;DUMP FORMAT says 1024 */
+#define RECLEN9 (5*1024)
 #define RECLEN7 (6*1024)
 #define RECLEN (seven_track ? RECLEN7 : RECLEN9)
 


### PR DESCRIPTION
Add -7 to use 7-track format: six frames per word, each frame with six data bit plus odd parity.

Add -B to read 32-bit record length in big endian format.

CC @eswenson1 