### PR TITLE
Add parameter to compiler calls allowing it to build on newer GCCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,14 @@ UNAME != uname
 -include $(UNAME).conf
 
 itstar: itstar.o dirlst.o pack.o tapeio.o tm03.o unpack.o zopen.o
-	cc -o itstar itstar.o dirlst.o pack.o tapeio.o \
+	cc --std=gnu11 -o itstar itstar.o dirlst.o pack.o tapeio.o \
 		tm03.o unpack.o zopen.o $(LIBS)
-	strip itstar
 
 .c.o: itstar.h
-	cc -O -c $<
+	cc --std=gnu11 -O -c $<
 
 tapeio.o: tapeio.c itstar.h tapsrv.h
-	cc -O -c tapeio.c
+	cc --std=gnu11 -O -c tapeio.c
 
 clean:
 	-rm *.o itstar


### PR DESCRIPTION
GCC has been updated to use a newer version of the C standard which prohibits things which used to be permitted. ITSTAR falls victim to this. Specifying an older standard (in this case `gnu11` works well) fixes this.